### PR TITLE
Remove `npm --prefix` usage from all framework extensions

### DIFF
--- a/frameworks/hello-world-react-cra/package.json
+++ b/frameworks/hello-world-react-cra/package.json
@@ -22,10 +22,10 @@
     ]
   },
   "scripts": {
-    "install:all": "npm install && npm --prefix ./webview-ui install ./webview-ui",
-    "start:webview": "npm --prefix ./webview-ui run start",
-    "test:webview": "npm --prefix ./webview-ui run test",
-    "build:webview": "npm --prefix ./webview-ui run build",
+    "install:all": "npm install && cd webview-ui && npm install",
+    "start:webview": "cd webview-ui && npm run start",
+    "build:webview": "cd webview-ui && npm run build",
+    "test:webview": "cd webview-ui && npm run test",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",

--- a/frameworks/hello-world-react-vite/package.json
+++ b/frameworks/hello-world-react-vite/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "scripts": {
-    "install:all": "npm install && npm --prefix ./webview-ui install ./webview-ui",
-    "start:webview": "npm --prefix ./webview-ui run start",
-    "build:webview": "npm --prefix ./webview-ui run build",
+    "install:all": "npm install && cd webview-ui && npm install",
+    "start:webview": "cd webview-ui && npm run start",
+    "build:webview": "cd webview-ui && npm run build",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",

--- a/frameworks/hello-world-solidjs/package.json
+++ b/frameworks/hello-world-solidjs/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "scripts": {
-    "install:all": "npm install && npm --prefix ./webview-ui install ./webview-ui",
-    "start:webview": "npm --prefix ./webview-ui run start",
-    "build:webview": "npm --prefix ./webview-ui run build",
+    "install:all": "npm install && cd webview-ui && npm install",
+    "start:webview": "cd webview-ui && npm run start",
+    "build:webview": "cd webview-ui && npm run build",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",

--- a/frameworks/hello-world-svelte/package.json
+++ b/frameworks/hello-world-svelte/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "scripts": {
-    "install:all": "npm install && npm --prefix ./webview-ui install ./webview-ui",
-    "start:webview": "npm --prefix ./webview-ui run dev",
-    "build:webview": "npm --prefix ./webview-ui run build",
+    "install:all": "npm install && cd webview-ui && npm install",
+    "start:webview": "cd webview-ui && npm run dev",
+    "build:webview": "cd webview-ui && npm run build",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",

--- a/frameworks/hello-world-vue/package.json
+++ b/frameworks/hello-world-vue/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "scripts": {
-    "install:all": "npm install && npm --prefix ./webview-ui install ./webview-ui",
-    "start:webview": "npm --prefix ./webview-ui run start",
-    "build:webview": "npm --prefix ./webview-ui run build",
+    "install:all": "npm install && cd webview-ui && npm install",
+    "start:webview": "cd webview-ui && npm run start",
+    "build:webview": "cd webview-ui && npm run build",
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added or changed by your pull request.
-->

### Link to relevant issue

Related to #98

### Description of changes

Removes all usage of `npm --prefix` in framework npm scripts.
