### PR TITLE
Update HelloWorldPanel.ts

### DIFF
--- a/default/hello-world/src/panels/HelloWorldPanel.ts
+++ b/default/hello-world/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);


### PR DESCRIPTION
this.dispose on line 30 should be changed with () => this.dispose() since it results in uncaught error on disposal of the panel. In order to caught the error, you may try the following code in the dispose method. 
```
try{
    HelloWorldPanel.currentPanel = undefined;

    // Dispose of the current webview panel
    this._panel.dispose();

    // Dispose of all disposables (i.e. commands) for the current webview panel
    while (this._disposables.length) {
      const disposable = this._disposables.pop();
      if (disposable) {
        disposable.dispose();
      }
    }
} catch (error){
console.log(error)
}
```
If I am not mistaken, then you will get an error that is similar to the following error.  

> TypeError: Cannot read properties of null (reading 'panel')
	at dispose (c:\Users\maini\Desktop\tag-manager\src\panels\StructuralSearchPanel.ts:48:12)
	at p.invoke (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:145)
	at v.deliver (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:2266)
	at b.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:1844)
	at u.dispose (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:92:198276)
	at s.$onDidDisposeWebviewPanel (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:92:200938)
	at i._doInvokeHandler (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:100:13680)
	at i._invokeHandler (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:100:13362)
	at i._receiveRequest (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:100:12132)
	at i._receiveOneMessage (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:100:10834)
	at c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:100:8941
	at p.invoke (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:145)
	at v.deliver (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:2266)
	at b.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:1844)
	at c.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:19049)
	at c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:116:17106
	at p.invoke (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:145)
	at v.deliver (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:2266)
	at b.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:1844)
	at c.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:19049)
	at s._receiveMessage (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:23861)
	at c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:21304
	at p.invoke (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:145)
	at v.deliver (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:2266)
	at b.fire (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:61:1844)
	at b.acceptChunk (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:15880)
	at c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:15010
	at Socket.d (c:\Users\maini\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:69:27128)
	at Socket.emit (C:\Users\maini\Desktop\tag-manager\lib\events.js:526:28)
	at addChunk (C:\Users\maini\Desktop\tag-manager\lib\internal\streams\readable.js:315:12)
	at readableAddChunk (C:\Users\maini\Desktop\tag-manager\lib\internal\streams\readable.js:289:9)
	at Socket.push (C:\Users\maini\Desktop\tag-manager\lib\internal\streams\readable.js:228:10)
	at Pipe.onStreamRead (C:\Users\maini\Desktop\tag-manager\lib\internal\stream_base_commons.js:190:23)
	at Pipe.callbackTrampoline (node:internal/async_hooks:130:17) {stack: 'TypeError: Cannot read properties of null (re…Trampoline (node:internal/async_hooks:130:17)', message: 'Cannot read properties of null (reading 'panel')'}

This error is from another panel that I wrote. However, the disposal mechanism is exactly same with this panel and the error is fixed when I changed "this.panel.onDidDispose(this.dispose, null, this.disposables)" line with  "this.panel.onDidDispose(() => this.dispose(), null, this.disposables)".

In the picture, you may see the uncaught error warning after the disposal of the panel, which is UI of the tag-manager extension.
![BugOnDisposal](https://user-images.githubusercontent.com/70061897/195594468-dafce585-9327-4b4e-b75d-639497b94bb8.png)

