### PR TITLE
Fix null disposal bug in all samples

### DIFF
--- a/default/component-gallery/src/panels/ComponentGalleryPanel.ts
+++ b/default/component-gallery/src/panels/ComponentGalleryPanel.ts
@@ -39,7 +39,7 @@ export class ComponentGalleryPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/default/component-gallery/src/panels/ComponentGalleryPanel.ts
+++ b/default/component-gallery/src/panels/ComponentGalleryPanel.ts
@@ -39,7 +39,7 @@ export class ComponentGalleryPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/default/hello-world/src/panels/HelloWorldPanel.ts
+++ b/default/hello-world/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/default/hello-world/src/panels/HelloWorldPanel.ts
+++ b/default/hello-world/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-angular/package-lock.json
+++ b/frameworks/hello-world-angular/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world-vue",
+  "name": "hello-world-angular",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world-vue",
+      "name": "hello-world-angular",
       "version": "0.0.1",
       "devDependencies": {
         "@types/glob": "^7.1.3",

--- a/frameworks/hello-world-angular/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-angular/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-angular/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-angular/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-react-cra/package-lock.json
+++ b/frameworks/hello-world-react-cra/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world-cra",
+  "name": "hello-world-react-cra",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world-cra",
+      "name": "hello-world-react-cra",
       "version": "0.0.1",
       "devDependencies": {
         "@types/glob": "^7.1.3",

--- a/frameworks/hello-world-react-cra/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-react-cra/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-react-cra/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-react-cra/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-react-vite/package-lock.json
+++ b/frameworks/hello-world-react-vite/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world",
+  "name": "hello-world-react-vite",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world",
+      "name": "hello-world-react-vite",
       "version": "0.0.1",
       "devDependencies": {
         "@types/glob": "^7.1.3",

--- a/frameworks/hello-world-react-vite/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-react-vite/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-react-vite/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-react-vite/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-solidjs/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-solidjs/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-solidjs/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-solidjs/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-svelte/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-svelte/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-svelte/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-svelte/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-vue/package-lock.json
+++ b/frameworks/hello-world-vue/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world-solidjs",
+  "name": "hello-world-vue",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world-solidjs",
+      "name": "hello-world-vue",
       "version": "0.0.1",
       "devDependencies": {
         "@types/glob": "^7.1.3",

--- a/frameworks/hello-world-vue/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-vue/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, this, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/frameworks/hello-world-vue/src/panels/HelloWorldPanel.ts
+++ b/frameworks/hello-world-vue/src/panels/HelloWorldPanel.ts
@@ -27,7 +27,7 @@ export class HelloWorldPanel {
 
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(this.dispose, this, this._disposables);
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added or changed by your pull request.
-->

### Link to relevant issue

This pull request resolves #122 

### Description of changes

Fixes a bug where all sample extensions (except for `notepad` and `weather-webview`) were failing to properly dispose of webview panel resources when closed.
