### PR TITLE
Fix `allComponents` registration API typo

### DIFF
--- a/default/component-gallery/src/webview/main.ts
+++ b/default/component-gallery/src/webview/main.ts
@@ -1,52 +1,14 @@
 import {
+  allComponents,
   provideVSCodeDesignSystem,
   Checkbox,
   DataGrid,
-  vsCodeBadge,
-  vsCodeButton,
-  vsCodeCheckbox,
-  vsCodeDataGrid,
-  vsCodeDataGridCell,
-  vsCodeDataGridRow,
-  vsCodeDivider,
-  vsCodeDropdown,
-  vsCodeLink,
-  vsCodeOption,
-  vsCodePanels,
-  vsCodePanelTab,
-  vsCodePanelView,
-  vsCodeProgressRing,
-  vsCodeRadio,
-  vsCodeRadioGroup,
-  vsCodeTag,
-  vsCodeTextArea,
-  vsCodeTextField,
 } from "@vscode/webview-ui-toolkit";
 
-// In order to use the Webview UI Toolkit web components they
+// In order to use all the Webview UI Toolkit web components they
 // must be registered with the browser (i.e. webview) using the
 // syntax below.
-provideVSCodeDesignSystem().register(
-  vsCodeBadge(),
-  vsCodeButton(),
-  vsCodeCheckbox(),
-  vsCodeDataGrid(),
-  vsCodeDataGridCell(),
-  vsCodeDataGridRow(),
-  vsCodeDivider(),
-  vsCodeDropdown(),
-  vsCodeLink(),
-  vsCodeOption(),
-  vsCodePanels(),
-  vsCodePanelTab(),
-  vsCodePanelView(),
-  vsCodeProgressRing(),
-  vsCodeRadio(),
-  vsCodeRadioGroup(),
-  vsCodeTag(),
-  vsCodeTextArea(),
-  vsCodeTextField()
-);
+provideVSCodeDesignSystem().register(allComponents);
 
 // Just like a regular webpage we need to wait for the webview
 // DOM to load before we can reference any of the HTML elements

--- a/default/hello-world-webpack/src/webview/main.ts
+++ b/default/hello-world-webpack/src/webview/main.ts
@@ -12,6 +12,11 @@ import { provideVSCodeDesignSystem, vsCodeButton, Button } from "@vscode/webview
 //   vsCodeButton(),
 //   vsCodeCheckbox()
 // );
+// 
+// Finally, if you would like to register all of the toolkit
+// components at once, there's a handy convenience function:
+//
+// provideVSCodeDesignSystem().register(allComponents);
 //
 provideVSCodeDesignSystem().register(vsCodeButton());
 

--- a/default/hello-world/src/webview/main.ts
+++ b/default/hello-world/src/webview/main.ts
@@ -13,6 +13,11 @@ import { provideVSCodeDesignSystem, vsCodeButton, Button } from "@vscode/webview
 //   vsCodeCheckbox()
 // );
 //
+// Finally, if you would like to register all of the toolkit
+// components at once, there's a handy convenience function:
+//
+// provideVSCodeDesignSystem().register(allComponents);
+// 
 provideVSCodeDesignSystem().register(vsCodeButton());
 
 // Get access to the VS Code API from within the webview context

--- a/frameworks/hello-world-angular/webview-ui/src/app/app.component.ts
+++ b/frameworks/hello-world-angular/webview-ui/src/app/app.component.ts
@@ -15,6 +15,11 @@ provideVSCodeDesignSystem().register(vsCodeButton());
 //   vsCodeButton(),
 //   vsCodeCheckbox()
 // );
+// 
+// Finally, if you would like to register all of the toolkit
+// components at once, there's a handy convenience function:
+//
+// provideVSCodeDesignSystem().register(allComponents);
 
 @Component({
   selector: "app-root",

--- a/frameworks/hello-world-solidjs/webview-ui/src/App.tsx
+++ b/frameworks/hello-world-solidjs/webview-ui/src/App.tsx
@@ -20,7 +20,7 @@ provideVSCodeDesignSystem().register(vsCodeButton());
 // Finally, if you would like to register all of the toolkit
 // components at once, there's a handy convenience function:
 //
-// provideVSCodeDesignSystem().register(allComponents.register());
+// provideVSCodeDesignSystem().register(allComponents);
 
 const App: Component = () => {
   function handleHowdyClick() {

--- a/frameworks/hello-world-vue/webview-ui/src/App.vue
+++ b/frameworks/hello-world-vue/webview-ui/src/App.vue
@@ -19,7 +19,7 @@ provideVSCodeDesignSystem().register(vsCodeButton());
 // Finally, if you would like to register all of the toolkit
 // components at once, there's a handy convenience function:
 //
-// provideVSCodeDesignSystem().register(allComponents.register());
+// provideVSCodeDesignSystem().register(allComponents);
 
 function handleHowdyClick() {
   vscode.postMessage({


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added or changed by your pull request.
-->

### Description of changes

Fixes a typo in most sample extensions that incorrectly stated the following could be used to register all the components:

```js
provideVSCodeDesignSystem().register(allComponents.register());
```

Instead the correct, API is:

```js
provideVSCodeDesignSystem().register(allComponents);
```

### Misc

Related PR: #132
