### PR TITLE
Update component gallery examples to fix radio bug

### DIFF
--- a/default/component-gallery/src/panels/demos/radio-group.ts
+++ b/default/component-gallery/src/panels/demos/radio-group.ts
@@ -1,3 +1,7 @@
+// Note: There is a known bug with vscode-radio component selection on first interaction. A workaround fix is 
+// to make sure that all radio components have a unique `value` attribute applied as demonstrated below.
+// Read more about the issue here: https://github.com/microsoft/vscode-webview-ui-toolkit/issues/476
+
 export const radioGroupDemo = /*html*/ `
   <section class="component-container">
     <h2>Radio Group + Radio</h2>
@@ -5,36 +9,36 @@ export const radioGroupDemo = /*html*/ `
       <p>Default Radio Group</p>
       <vscode-radio-group>
         <label slot="label">Group Label</label>
-        <vscode-radio>Label</vscode-radio>
-        <vscode-radio>Label</vscode-radio>
-        <vscode-radio>Label</vscode-radio>
+        <vscode-radio value="value-1">Label</vscode-radio>
+        <vscode-radio value="value-2">Label</vscode-radio>
+        <vscode-radio value="value-3">Label</vscode-radio>
       </vscode-radio-group>
     </section>
     <section class="component-example">
       <p>With Disabled</p>
       <vscode-radio-group disabled>
         <label slot="label">Group Label</label>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
+        <vscode-radio value="value-1">Radio Label</vscode-radio>
+        <vscode-radio value="value-2">Radio Label</vscode-radio>
+        <vscode-radio value="value-3">Radio Label</vscode-radio>
       </vscode-radio-group>
     </section>
     <section class="component-example">
       <p>With Readonly</p>
       <vscode-radio-group readonly>
         <label slot="label">Group Label</label>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
+        <vscode-radio value="value-1">Radio Label</vscode-radio>
+        <vscode-radio value="value-2">Radio Label</vscode-radio>
+        <vscode-radio value="value-3">Radio Label</vscode-radio>
       </vscode-radio-group>
     </section>
     <section class="component-example">
       <p>With Vertical Orientation</p>
       <vscode-radio-group orientation="vertical">
         <label slot="label">Group Label</label>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
-        <vscode-radio>Radio Label</vscode-radio>
+        <vscode-radio value="value-1">Radio Label</vscode-radio>
+        <vscode-radio value="value-2">Radio Label</vscode-radio>
+        <vscode-radio value="value-3">Radio Label</vscode-radio>
       </vscode-radio-group>
     </section>
   </section>

--- a/frameworks/component-gallery-react/webview-ui/src/demos/RadioGroupDemo.tsx
+++ b/frameworks/component-gallery-react/webview-ui/src/demos/RadioGroupDemo.tsx
@@ -1,5 +1,9 @@
 import { VSCodeRadio, VSCodeRadioGroup } from "@vscode/webview-ui-toolkit/react";
 
+// Note: There is a known bug with VSCodeRadio component selection on first interaction. A workaround fix is 
+// to make sure that all radio components have a unique `value` attribute applied as demonstrated below.
+// Read more about the issue here: https://github.com/microsoft/vscode-webview-ui-toolkit/issues/476
+
 export function RadioGroupDemo() {
   return (
     <section className="component-container">
@@ -8,36 +12,36 @@ export function RadioGroupDemo() {
         <p>Default Radio Group</p>
         <VSCodeRadioGroup>
           <label slot="label">Group Label</label>
-          <VSCodeRadio>Label</VSCodeRadio>
-          <VSCodeRadio>Label</VSCodeRadio>
-          <VSCodeRadio>Label</VSCodeRadio>
+          <VSCodeRadio value="value-1">Label</VSCodeRadio>
+          <VSCodeRadio value="value-2">Label</VSCodeRadio>
+          <VSCodeRadio value="value-3">Label</VSCodeRadio>
         </VSCodeRadioGroup>
       </section>
       <section className="component-example">
         <p>With Disabled</p>
         <VSCodeRadioGroup disabled>
           <label slot="label">Group Label</label>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-1">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-2">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-3">Radio Label</VSCodeRadio>
         </VSCodeRadioGroup>
       </section>
       <section className="component-example">
         <p>With Readonly</p>
         <VSCodeRadioGroup readOnly>
           <label slot="label">Group Label</label>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-1">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-2">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-3">Radio Label</VSCodeRadio>
         </VSCodeRadioGroup>
       </section>
       <section className="component-example">
         <p>With Vertical Orientation</p>
         <VSCodeRadioGroup orientation="vertical">
           <label slot="label">Group Label</label>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
-          <VSCodeRadio>Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-1">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-2">Radio Label</VSCodeRadio>
+          <VSCodeRadio value="value-3">Radio Label</VSCodeRadio>
         </VSCodeRadioGroup>
       </section>
     </section>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added or changed by your pull request.
-->

### Description of changes

There is a [known bug](https://github.com/microsoft/vscode-webview-ui-toolkit/issues/476) with `vscode-radio` component selection on first interaction. A workaround fix is to make sure that all radio components have a unique `value` attribute applied like demonstrated below. Both component gallery samles have been updated to reflect this fix.
